### PR TITLE
feat: full CLI — store, query, list, stats, dedup

### DIFF
--- a/mem/cli.py
+++ b/mem/cli.py
@@ -1,76 +1,241 @@
 """CLI entrypoint for personal-memory (mem)."""
 
-import argparse
+from __future__ import annotations
+
+import json as _json
 import sys
 
+import click
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="mem",
-        description="Personal semantic memory backed by sqlite-vec.",
+from mem.store import MemoryStore
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _store() -> MemoryStore:
+    return MemoryStore()
+
+
+def _score_color(score: float) -> str:
+    if score >= 0.7:
+        return "green"
+    if score >= 0.4:
+        return "yellow"
+    return "red"
+
+
+# ---------------------------------------------------------------------------
+# CLI group
+# ---------------------------------------------------------------------------
+
+@click.group()
+@click.version_option("0.1.0")
+def cli() -> None:
+    """Personal semantic memory backed by sqlite-vec."""
+
+
+# ---------------------------------------------------------------------------
+# mem store
+# ---------------------------------------------------------------------------
+
+@cli.command("store")
+@click.argument("text", required=False)
+@click.option("--file", "-f", "filepath", type=click.Path(exists=True),
+              help="Ingest a file instead of inline text.")
+@click.option("--stdin", "from_stdin", is_flag=True,
+              help="Read text from stdin.")
+@click.option("--source", "-s", default=None, help="Label for this memory's source.")
+@click.option("--tag", "-t", "tags", multiple=True, help="Tags (repeatable).")
+def store_cmd(
+    text: str | None,
+    filepath: str | None,
+    from_stdin: bool,
+    source: str | None,
+    tags: tuple[str, ...],
+) -> None:
+    """Store text in memory.
+
+    Provide TEXT inline, --file PATH, or --stdin.
+    """
+    if from_stdin:
+        content = sys.stdin.read()
+    elif filepath:
+        with open(filepath) as fh:
+            content = fh.read()
+        if source is None:
+            source = filepath
+    elif text:
+        content = text
+    else:
+        raise click.UsageError("Provide TEXT, --file, or --stdin.")
+
+    with _store() as s:
+        stored, skipped = s.add(content, source=source, tags=list(tags))
+
+    click.echo(f"Stored {stored} chunk(s).", err=False)
+    if skipped:
+        click.echo(f"Skipped {skipped} duplicate chunk(s).", err=False)
+
+
+# ---------------------------------------------------------------------------
+# mem query
+# ---------------------------------------------------------------------------
+
+@cli.command("query")
+@click.argument("text")
+@click.option("-k", "--top-k", default=5, show_default=True,
+              help="Number of results to return.")
+@click.option("--semantic-weight", default=0.8, show_default=True,
+              help="Weight for semantic similarity (0–1).")
+@click.option("--recency-weight", default=0.2, show_default=True,
+              help="Weight for recency (0–1). Must sum to 1 with --semantic-weight.")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+def query_cmd(
+    text: str,
+    top_k: int,
+    semantic_weight: float,
+    recency_weight: float,
+    as_json: bool,
+) -> None:
+    """Query memory by semantic similarity."""
+    from mem.embedder import embed
+    from mem.retriever import Retriever
+
+    query_vec = embed(text)
+
+    with _store() as s:
+        retriever = Retriever(s, semantic_weight=semantic_weight,
+                              recency_weight=recency_weight)
+        results = retriever.retrieve(query_vec, top_k=top_k)
+
+    if as_json:
+        output = [
+            {
+                "id": r.memory.id,
+                "chunk_text": r.memory.chunk_text,
+                "source": r.memory.source,
+                "tags": r.memory.tags,
+                "created_at": r.memory.created_at.isoformat(),
+                "semantic_score": round(r.semantic_score, 4),
+                "recency_score": round(r.recency_score, 4),
+                "final_score": round(r.final_score, 4),
+            }
+            for r in results
+        ]
+        click.echo(_json.dumps(output, indent=2))
+        return
+
+    if not results:
+        click.echo("No results found.")
+        return
+
+    for i, r in enumerate(results, 1):
+        score_str = click.style(f"{r.final_score:.3f}", fg=_score_color(r.final_score))
+        source_str = click.style(r.memory.source or "—", dim=True)
+        click.echo(f"\n{i}. [{score_str}] {source_str}")
+        click.echo(f"   {r.memory.chunk_text}")
+
+
+# ---------------------------------------------------------------------------
+# mem list
+# ---------------------------------------------------------------------------
+
+@cli.command("list")
+@click.option("-n", default=20, show_default=True, help="Number of entries to show.")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+def list_cmd(n: int, as_json: bool) -> None:
+    """Show recent memory entries."""
+    with _store() as s:
+        rows = s._con.execute(
+            "SELECT id, chunk_text, source, tags, created_at FROM memories "
+            "ORDER BY created_at DESC LIMIT ?",
+            (n,),
+        ).fetchall()
+
+    if as_json:
+        click.echo(_json.dumps(
+            [dict(r) for r in rows], indent=2, default=str
+        ))
+        return
+
+    if not rows:
+        click.echo("No memories stored yet.")
+        return
+
+    for r in rows:
+        ts = click.style(r["created_at"][:19], dim=True)
+        src = click.style(r["source"] or "—", dim=True)
+        preview = r["chunk_text"][:80].replace("\n", " ")
+        click.echo(f"[{r['id']}] {ts}  {src}\n    {preview}")
+
+
+# ---------------------------------------------------------------------------
+# mem stats
+# ---------------------------------------------------------------------------
+
+@cli.command("stats")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+def stats_cmd(as_json: bool) -> None:
+    """Show memory store statistics."""
+    with _store() as s:
+        count = s.count()
+        sources = s.list_sources()
+        row = s._con.execute(
+            "SELECT MIN(created_at) AS oldest, MAX(created_at) AS newest FROM memories"
+        ).fetchone()
+
+    data = {
+        "total_chunks": count,
+        "sources": sources,
+        "oldest": row["oldest"],
+        "newest": row["newest"],
+    }
+
+    if as_json:
+        click.echo(_json.dumps(data, indent=2))
+        return
+
+    click.echo(f"Total chunks : {count}")
+    click.echo(f"Sources      : {', '.join(sources) if sources else '—'}")
+    click.echo(f"Oldest       : {data['oldest'] or '—'}")
+    click.echo(f"Newest       : {data['newest'] or '—'}")
+
+
+# ---------------------------------------------------------------------------
+# mem dedup
+# ---------------------------------------------------------------------------
+
+@cli.command("dedup")
+@click.option("--dry-run", is_flag=True,
+              help="Report duplicates without deleting.")
+def dedup_cmd(dry_run: bool) -> None:
+    """Find (and optionally report) duplicate chunks in the DB."""
+    with _store() as s:
+        dupes = s.find_duplicates()
+
+    if not dupes:
+        click.echo("No duplicates found.")
+        return
+
+    total_extra = sum(len(ids) - 1 for ids in dupes.values())
+    click.echo(
+        f"Found {len(dupes)} duplicated fingerprint(s) — "
+        f"{total_extra} redundant row(s)."
     )
-    parser.add_argument(
-        "--version", action="version", version="%(prog)s 0.1.0"
-    )
-
-    sub = parser.add_subparsers(dest="command", metavar="COMMAND")
-
-    # mem store
-    store_p = sub.add_parser("store", help="Store text in memory.")
-    store_p.add_argument("text", help="Text to store.")
-
-    # mem query
-    query_p = sub.add_parser("query", help="Query memory by semantic similarity.")
-    query_p.add_argument("text", help="Query text.")
-    query_p.add_argument(
-        "-k", "--top-k", type=int, default=5, metavar="K",
-        help="Number of results to return (default: 5).",
-    )
-
-    # mem dedup
-    dedup_p = sub.add_parser("dedup", help="Find duplicate chunks in the DB.")
-    dedup_p.add_argument(
-        "--dry-run", action="store_true",
-        help="Report duplicates without deleting them.",
-    )
-
-    return parser
+    if dry_run:
+        for fp, ids in dupes.items():
+            click.echo(f"  {fp[:16]}…  ids={ids}")
 
 
-def main(argv: list[str] | None = None) -> int:
-    parser = build_parser()
-    args = parser.parse_args(argv)
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
 
-    if args.command is None:
-        parser.print_help()
-        return 0
-
-    if args.command == "store":
-        # Placeholder — wired up in issue #7 (CLI)
-        print(f"[store] Not yet implemented. Text: {args.text!r}")
-        return 0
-
-    if args.command == "query":
-        # Placeholder — wired up in issue #7 (CLI)
-        print(f"[query] Not yet implemented. Query: {args.text!r}, top_k={args.top_k}")
-        return 0
-
-    if args.command == "dedup":
-        from mem.store import MemoryStore
-        with MemoryStore() as store:
-            dupes = store.find_duplicates()
-        if not dupes:
-            print("No duplicates found.")
-            return 0
-        total_extra = sum(len(ids) - 1 for ids in dupes.values())
-        print(f"Found {len(dupes)} duplicated fingerprint(s) — {total_extra} redundant row(s).")
-        if args.dry_run:
-            for fp, ids in dupes.items():
-                print(f"  {fp[:16]}…  ids={ids}")
-        return 0
-
-    return 1
+def main() -> None:
+    cli()
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "anthropic>=0.84.0",
+    "click>=8.3.1",
     "openai>=2.26.0",
     "sqlite-vec>=0.1.6",
 ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,237 @@
+"""Tests for the mem CLI (click commands)."""
+
+from __future__ import annotations
+
+import json
+import math
+import random
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from mem.cli import cli
+from mem.store import MemoryStore
+
+_DIM = 1536
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _rand_vec(seed: int = 0) -> list[float]:
+    rng = random.Random(seed)
+    v = [rng.gauss(0, 1) for _ in range(_DIM)]
+    n = math.sqrt(sum(x * x for x in v))
+    return [x / n for x in v]
+
+
+def _patch_embed_batch(texts):
+    return [_rand_vec(i) for i in range(len(texts))]
+
+
+def _patch_embed(text):
+    return _rand_vec(0)
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return tmp_path / "mem.db"
+
+
+@pytest.fixture
+def populated_store(db_path):
+    """A store pre-loaded with a few chunks (no real API calls)."""
+    with MemoryStore(db_path) as s:
+        for i in range(5):
+            s.insert(f"Chunk {i}: some text about topic {i}.",
+                     _rand_vec(i),
+                     source=f"source-{i % 2}",
+                     fingerprint=f"fp-{i}")
+    return db_path
+
+
+def _cli_store(db_path: Path):
+    """Context manager that patches MemoryStore to use tmp db."""
+    return patch("mem.cli._store", return_value=MemoryStore(db_path))
+
+
+# ---------------------------------------------------------------------------
+# mem store
+# ---------------------------------------------------------------------------
+
+class TestStoreCmd:
+    def test_store_inline_text(self, runner, db_path):
+        with patch("mem.cli._store", return_value=MemoryStore(db_path)), \
+             patch("mem.embedder.embed_batch", side_effect=_patch_embed_batch):
+            result = runner.invoke(cli, ["store", "Hello world."])
+        assert result.exit_code == 0
+        assert "Stored" in result.output
+
+    def test_store_from_file(self, runner, db_path, tmp_path):
+        f = tmp_path / "note.txt"
+        f.write_text("Content from a file.")
+        with patch("mem.cli._store", return_value=MemoryStore(db_path)), \
+             patch("mem.embedder.embed_batch", side_effect=_patch_embed_batch):
+            result = runner.invoke(cli, ["store", "--file", str(f)])
+        assert result.exit_code == 0
+        assert "Stored" in result.output
+
+    def test_store_from_stdin(self, runner, db_path):
+        with patch("mem.cli._store", return_value=MemoryStore(db_path)), \
+             patch("mem.embedder.embed_batch", side_effect=_patch_embed_batch):
+            result = runner.invoke(cli, ["store", "--stdin"], input="stdin text")
+        assert result.exit_code == 0
+        assert "Stored" in result.output
+
+    def test_store_reports_skipped_duplicates(self, runner, db_path):
+        args = ["store", "Same text. Stored twice."]
+        with patch("mem.cli._store", return_value=MemoryStore(db_path)), \
+             patch("mem.embedder.embed_batch", side_effect=_patch_embed_batch):
+            runner.invoke(cli, args)
+        with patch("mem.cli._store", return_value=MemoryStore(db_path)), \
+             patch("mem.embedder.embed_batch", side_effect=_patch_embed_batch):
+            result = runner.invoke(cli, args)
+        assert "Skipped" in result.output
+
+    def test_store_no_input_shows_error(self, runner, db_path):
+        with patch("mem.cli._store", return_value=MemoryStore(db_path)):
+            result = runner.invoke(cli, ["store"])
+        assert result.exit_code != 0
+
+    def test_store_with_source_and_tags(self, runner, db_path):
+        with patch("mem.cli._store", return_value=MemoryStore(db_path)), \
+             patch("mem.embedder.embed_batch", side_effect=_patch_embed_batch):
+            result = runner.invoke(
+                cli, ["store", "tagged text", "--source", "wiki", "--tag", "ai"]
+            )
+        assert result.exit_code == 0
+        with MemoryStore(db_path) as s:
+            assert "wiki" in s.list_sources()
+
+
+# ---------------------------------------------------------------------------
+# mem query
+# ---------------------------------------------------------------------------
+
+class TestQueryCmd:
+    def test_query_no_results(self, runner, db_path):
+        with patch("mem.cli._store", return_value=MemoryStore(db_path)), \
+             patch("mem.embedder.embed", return_value=_rand_vec(0)):
+            result = runner.invoke(cli, ["query", "something"])
+        assert result.exit_code == 0
+        assert "No results" in result.output
+
+    def test_query_returns_results(self, runner, populated_store):
+        with patch("mem.cli._store", return_value=MemoryStore(populated_store)), \
+             patch("mem.embedder.embed", return_value=_rand_vec(0)):
+            result = runner.invoke(cli, ["query", "topic"])
+        assert result.exit_code == 0
+        assert "Chunk" in result.output
+
+    def test_query_json_output(self, runner, populated_store):
+        with patch("mem.cli._store", return_value=MemoryStore(populated_store)), \
+             patch("mem.embedder.embed", return_value=_rand_vec(0)):
+            result = runner.invoke(cli, ["query", "topic", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert all("chunk_text" in item for item in data)
+
+    def test_query_top_k_respected(self, runner, populated_store):
+        with patch("mem.cli._store", return_value=MemoryStore(populated_store)), \
+             patch("mem.embedder.embed", return_value=_rand_vec(0)):
+            result = runner.invoke(cli, ["query", "topic", "-k", "2", "--json"])
+        data = json.loads(result.output)
+        assert len(data) <= 2
+
+
+# ---------------------------------------------------------------------------
+# mem list
+# ---------------------------------------------------------------------------
+
+class TestListCmd:
+    def test_list_empty(self, runner, db_path):
+        with patch("mem.cli._store", return_value=MemoryStore(db_path)):
+            result = runner.invoke(cli, ["list"])
+        assert result.exit_code == 0
+        assert "No memories" in result.output
+
+    def test_list_shows_entries(self, runner, populated_store):
+        with patch("mem.cli._store", return_value=MemoryStore(populated_store)):
+            result = runner.invoke(cli, ["list"])
+        assert result.exit_code == 0
+        assert "Chunk" in result.output
+
+    def test_list_json(self, runner, populated_store):
+        with patch("mem.cli._store", return_value=MemoryStore(populated_store)):
+            result = runner.invoke(cli, ["list", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) == 5
+
+    def test_list_n_limit(self, runner, populated_store):
+        with patch("mem.cli._store", return_value=MemoryStore(populated_store)):
+            result = runner.invoke(cli, ["list", "-n", "2", "--json"])
+        data = json.loads(result.output)
+        assert len(data) == 2
+
+
+# ---------------------------------------------------------------------------
+# mem stats
+# ---------------------------------------------------------------------------
+
+class TestStatsCmd:
+    def test_stats_empty(self, runner, db_path):
+        with patch("mem.cli._store", return_value=MemoryStore(db_path)):
+            result = runner.invoke(cli, ["stats"])
+        assert result.exit_code == 0
+        assert "0" in result.output
+
+    def test_stats_shows_count(self, runner, populated_store):
+        with patch("mem.cli._store", return_value=MemoryStore(populated_store)):
+            result = runner.invoke(cli, ["stats"])
+        assert result.exit_code == 0
+        assert "5" in result.output
+
+    def test_stats_json(self, runner, populated_store):
+        with patch("mem.cli._store", return_value=MemoryStore(populated_store)):
+            result = runner.invoke(cli, ["stats", "--json"])
+        data = json.loads(result.output)
+        assert data["total_chunks"] == 5
+        assert isinstance(data["sources"], list)
+
+    def test_stats_lists_sources(self, runner, populated_store):
+        with patch("mem.cli._store", return_value=MemoryStore(populated_store)):
+            result = runner.invoke(cli, ["stats"])
+        assert "source-0" in result.output or "source-1" in result.output
+
+
+# ---------------------------------------------------------------------------
+# mem dedup
+# ---------------------------------------------------------------------------
+
+class TestDedupCmd:
+    def test_dedup_no_dupes(self, runner, populated_store):
+        with patch("mem.cli._store", return_value=MemoryStore(populated_store)):
+            result = runner.invoke(cli, ["dedup"])
+        assert result.exit_code == 0
+        assert "No duplicates" in result.output
+
+    def test_dedup_dry_run_reports(self, runner, db_path):
+        with MemoryStore(db_path) as s:
+            s.insert("x", _rand_vec(0), fingerprint="dup-fp")
+            s.insert("x", _rand_vec(1), fingerprint="dup-fp")
+        with patch("mem.cli._store", return_value=MemoryStore(db_path)):
+            result = runner.invoke(cli, ["dedup", "--dry-run"])
+        assert result.exit_code == 0
+        assert "1 duplicated" in result.output
+        assert "dup-fp"[:8] in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -53,6 +53,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -236,6 +248,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "click" },
     { name = "openai" },
     { name = "sqlite-vec" },
 ]
@@ -248,6 +261,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.84.0" },
+    { name = "click", specifier = ">=8.3.1" },
     { name = "openai", specifier = ">=2.26.0" },
     { name = "sqlite-vec", specifier = ">=0.1.6" },
 ]


### PR DESCRIPTION
## Summary
Complete click-based CLI replacing the argparse stub.

| Command | What it does |
|---------|-------------|
| `mem store TEXT` | Inline text, `--file PATH`, or `--stdin`; `--source`, `--tag` |
| `mem query TEXT` | Semantic + recency retrieval; colored scores; `--json` |
| `mem list` | Recent 20 entries (or `-n N`); `--json` |
| `mem stats` | Count, sources, oldest/newest; `--json` |
| `mem dedup` | Duplicate report; `--dry-run` |

## Highlights
- Color-coded scores in `query` output (green ≥ 0.7, yellow ≥ 0.4, red below)
- `--json` flag on every read command for scripting
- `store` reports skipped duplicates: _"Skipped 3 duplicate chunk(s)."_
- `store --file` auto-sets `--source` to the file path

## Test plan
- [x] 20 tests in `tests/test_cli.py` via `click.testing.CliRunner`
- [x] All commands, `--json` output, `--stdin`, file ingestion, tag propagation, dedup dry-run
- [x] All 92 tests pass: `uv run pytest tests/ -q`

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)